### PR TITLE
Implement cache busting for our own static files

### DIFF
--- a/pgcommitfest/commitfest/templates/base.html
+++ b/pgcommitfest/commitfest/templates/base.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="/media/commitfest/css/jquery-ui.css" type="text/css">
   <link rel="stylesheet" href="/media/commitfest/css/bootstrap.css" />
   <link rel="stylesheet" href="/media/commitfest/css/bootstrap-theme.min.css" />
-  <link rel="stylesheet" href="/media/commitfest/css/commitfest.css" />
+  <link rel="stylesheet" href="/media/commitfest/css/commitfest.css?{% static_file_param %}" />
   <link rel="shortcut icon" href="/media/commitfest/favicon.ico" />
 {%block extrahead%}{%endblock%}
 {%if rss_alternate%}  <link rel="alternate" type="application/rss+xml" title="{{rss_alternate_title}}" href="{{rss_alternate}}" />{%endif%}
@@ -43,6 +43,6 @@
 <script src="/media/commitfest/js/jquery.js"></script>
 <script src="/media/commitfest/js/jquery-ui.js"></script>
 <script src="/media/commitfest/js/bootstrap.js"></script>
-<script src="/media/commitfest/js/commitfest.js"></script>
+<script src="/media/commitfest/js/commitfest.js?{% static_file_param %}"></script>
 {%block morescript%}{%endblock%}
 </html>

--- a/pgcommitfest/commitfest/templatetags/commitfest.py
+++ b/pgcommitfest/commitfest/templatetags/commitfest.py
@@ -1,5 +1,6 @@
 from django.template.defaultfilters import stringfilter
 from django import template
+from uuid import uuid4
 
 from pgcommitfest.commitfest.models import PatchOnCommitFest
 
@@ -41,6 +42,18 @@ def alertmap(value):
         return 'alert-success'
     else:
         return 'alert-info'
+
+
+# Generate a GET parameter that's unique per startup of the python process to
+# bust the cache of the client, so that it pulls in possibly updated JS/CSS
+# files.
+STATIC_FILE_PARAM = f"v={uuid4()}"
+
+
+# This GET parameter should be added to every one of our static files.
+@register.simple_tag
+def static_file_param():
+    return STATIC_FILE_PARAM
 
 
 @register.filter(name='hidemail')


### PR DESCRIPTION
Browsers cache static files. That's obviously good. Currently it results in our 
we change files server side, users don't always see them.

This generates a GET parameter that's unique per startup of the python process
to bust the cache of the client, so that it pulls in possibly updated JS/CSS
files. Obviously this is a bit more often than necessary, but caching should
still work most of the time and our custom css and js files are tiny anyway.
At least the changes that are made will now be reflected to our users.

