### PR TITLE
Default author to self when adding a new patch

### DIFF
--- a/pgcommitfest/commitfest/views.py
+++ b/pgcommitfest/commitfest/views.py
@@ -440,7 +440,7 @@ def newpatch(request, cfid):
             # Now add the thread
             try:
                 doAttachThread(cf, patch, form.cleaned_data['threadmsgid'], request.user)
-                return HttpResponseRedirect("/patch/%s/edit/" % (patch.id,))
+                return HttpResponseRedirect("/patch/%s/" % (patch.id,))
             except Http404:
                 # Thread not found!
                 # This is a horrible breakage of API layers
@@ -451,13 +451,14 @@ def newpatch(request, cfid):
             # not happen very often. If we successfully attached to it, we will have already returned.
             patch.delete()
     else:
-        form = NewPatchForm()
+        form = NewPatchForm(request=request)
 
     return render(request, 'base_form.html', {
         'form': form,
         'title': 'New patch',
         'breadcrumbs': [{'title': cf.title, 'href': '/%s/' % cf.pk}, ],
         'savebutton': 'Create patch',
+        'selectize_multiple_fields': form.selectize_multiple_fields.items(),
         'threadbrowse': True,
     })
 


### PR DESCRIPTION
People sometimes forget to configure the author field when adding a patch to the commitfest. It's also kinda silly to always have to search for your own name. In the cases that people add commitfest entries for patches of others, removing themselves and adding the other person is only a backspace presses away.

Apart from that this also updates the patch creation form to include all the fields from the patch edit form. Instead of having the patch creation submit button redirect to the patch edit page.

Fixes #14
