### PR TITLE
Autofill new patch description based on selected thread

### DIFF
--- a/pgcommitfest/commitfest/templates/base_form.html
+++ b/pgcommitfest/commitfest/templates/base_form.html
@@ -110,20 +110,5 @@ $('#searchUserModal').on('shown.bs.modal', function() {
 	  $('#searchUserSearchField').focus();
 });
 {%endif%}
-
-/* Build our button callbacks */
-$(document).ready(function() {
-   $('button.attachThreadButton').each(function (i,o) {
-      var b = $(o);
-      b.click(function() {
-	 $('#attachThreadAttachOnly').val('1');
-         browseThreads(function(msgid) {
-            b.prev().val(msgid);
-            return true;
-         });
-         return false;
-      });
-   });
-});
 </script>
 {%endblock%}


### PR DESCRIPTION
It's a bit silly that you have to manually enter something in the description, when you just selected a thing with that title from the thread search modal. So this starts auto-filling the description. This only happens when the field is empty, and will strip some common prefixes like `Re:` and `[PATCH]`.  

Fixes #16
