### PR TITLE
Disallow assigning others as reviewer/committer on open patches

### DIFF
--- a/pgcommitfest/commitfest/forms.py
+++ b/pgcommitfest/commitfest/forms.py
@@ -98,6 +98,14 @@ class PatchForm(forms.ModelForm):
                 u.username, u.get_full_name()
             )
 
+        # Only allow modifying reviewers and committers if the patch is closed.
+        if (
+            self.instance.id is None
+            or self.instance.current_patch_on_commitfest().is_open
+        ):
+            del self.fields["committer"]
+            del self.fields["reviewers"]
+
 
 class NewPatchForm(PatchForm):
     # Put threadmsgid first

--- a/pgcommitfest/commitfest/models.py
+++ b/pgcommitfest/commitfest/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.db import models
+from django.shortcuts import get_object_or_404
 
 from datetime import datetime
 
@@ -154,6 +155,10 @@ class Patch(models.Model, DiffableModel):
     def current_commitfest(self):
         return self.commitfests.order_by("-startdate").first()
 
+    def current_patch_on_commitfest(self):
+        cf = self.current_commitfest()
+        return get_object_or_404(PatchOnCommitFest, patch=self, commitfest=cf)
+
     # Some accessors
     @property
     def authors_string(self):
@@ -257,6 +262,10 @@ class PatchOnCommitFest(models.Model):
     @property
     def is_closed(self):
         return self.status not in self.OPEN_STATUSES
+
+    @property
+    def is_open(self):
+        return not self.is_closed
 
     @property
     def statusstring(self):


### PR DESCRIPTION
Many people assign themselves to open entries as a reviewer/committer as a sort of bookmarking system for open patches they are interested in. Currently it's allowed for others to assign anyone as a reviewer/committer, thus effectively modifying people their bookmarking system. This is especially made worse because you can sign up in your profile to receive email updates from the commitfest app for patches that you are reviewer/committer of and would then thus start receiving updates for patches you might not be interested in.

Assigning reviewers/committers to closed patches is still be allowed. When committing, reviewers are sometimes added by the committer to reflect the same as their Reviewed-By footer, even if those reviewers didn't explicitly sign up as a reviewer on the commitfest app for this patch.

Fixes #12
