### PR TITLE
Add reverse sorting on commitfest page

### DIFF
--- a/media/commitfest/js/commitfest.js
+++ b/media/commitfest/js/commitfest.js
@@ -257,12 +257,15 @@ function flagCommitted(committer) {
 }
 
 function sortpatches(sortby) {
-    if ($("#id_sortkey").val() === sortby) {
-        $("#id_sortkey").val(0);
-    } else {
-        $("#id_sortkey").val(sortby);
-    }
-    $("#filterform").submit();
+   let sortkey = $('#id_sortkey').val()
+   if (sortkey == sortby) {
+      $('#id_sortkey').val(-sortby)
+   } else if(-sortkey == sortby){
+      $('#id_sortkey').val(0)
+   } else {
+      $('#id_sortkey').val(sortby);
+   }
+   $('#filterform').submit();
 
     return false;
 }

--- a/media/commitfest/js/commitfest.js
+++ b/media/commitfest/js/commitfest.js
@@ -257,15 +257,15 @@ function flagCommitted(committer) {
 }
 
 function sortpatches(sortby) {
-   let sortkey = $('#id_sortkey').val()
-   if (sortkey == sortby) {
-      $('#id_sortkey').val(-sortby)
-   } else if(-sortkey == sortby){
-      $('#id_sortkey').val(0)
-   } else {
-      $('#id_sortkey').val(sortby);
-   }
-   $('#filterform').submit();
+    const sortkey = $("#id_sortkey").val();
+    if (sortkey === sortby) {
+        $("#id_sortkey").val(-sortby);
+    } else if (-sortkey === sortby) {
+        $("#id_sortkey").val(0);
+    } else {
+        $("#id_sortkey").val(sortby);
+    }
+    $("#filterform").submit();
 
     return false;
 }

--- a/pgcommitfest/commitfest/templates/commitfest.html
+++ b/pgcommitfest/commitfest/templates/commitfest.html
@@ -60,18 +60,18 @@
 <table class="table table-striped table-bordered table-hover table-condensed">
  <thead>
   <tr>
-   <th><a href="#" style="color:#333333;" onclick="return sortpatches(5);">Patch</a>{%if sortkey == 5%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%endif%}</th>
-   <th><a href="#" style="color:#333333;" onclick="return sortpatches(4);">ID</a>{%if sortkey == 4%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%endif%}</th>
+   <th><a href="#" style="color:#333333;" onclick="return sortpatches(5);">Patch</a>{%if sortkey == 5%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -5%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+   <th><a href="#" style="color:#333333;" onclick="return sortpatches(4);">ID</a>{%if sortkey == 4%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -4%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
    <th>Status</th>
    <th>Ver</th>
    <th>CI status</th>
-   <th><a href="#" style="color:#333333;" onclick="return sortpatches(6);">Stats</a>{%if sortkey == 6%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%endif%}</th>
+   <th><a href="#" style="color:#333333;" onclick="return sortpatches(6);">Stats</a>{%if sortkey == 6%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -6%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
    <th>Author</th>
    <th>Reviewers</th>
    <th>Committer</th>
-   <th><a href="#" style="color:#333333;" onclick="return sortpatches(3);">Num cfs</a>{%if sortkey == 3%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%endif%}</th>
-   <th><a href="#" style="color:#333333;" onclick="return sortpatches(1);">Latest activity</a>{%if sortkey == 1%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%endif%}</th>
-   <th><a href="#" style="color:#333333;" onclick="return sortpatches(2);">Latest mail</a>{%if sortkey == 2%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%endif%}</th>
+   <th><a href="#" style="color:#333333;" onclick="return sortpatches(3);">Num cfs</a>{%if sortkey == 3%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -3%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+   <th><a href="#" style="color:#333333;" onclick="return sortpatches(1);">Latest activity</a>{%if sortkey == 1%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -1%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+   <th><a href="#" style="color:#333333;" onclick="return sortpatches(2);">Latest mail</a>{%if sortkey == 2%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -2%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
 {%if user.is_staff%}
    <th>Select</th>
 {%endif%}

--- a/pgcommitfest/commitfest/views.py
+++ b/pgcommitfest/commitfest/views.py
@@ -264,9 +264,7 @@ def commitfest(request, cfid):
                 "branch.all_additions + branch.all_deletions NULLS LAST, created"
             )
         elif sortkey == -6:
-            orderby_str = (
-                "branch.all_additions + branch.all_deletions DESC NULLS LAST, created"
-            )
+            orderby_str = "branch.all_additions + branch.all_deletions DESC NULLS LAST, created DESC"
         else:
             orderby_str = "p.id"
             sortkey = 0

--- a/pgcommitfest/commitfest/views.py
+++ b/pgcommitfest/commitfest/views.py
@@ -241,17 +241,31 @@ def commitfest(request, cfid):
 
         if sortkey == 1:
             orderby_str = "modified, created"
+        elif sortkey == -1:
+            orderby_str = "modified DESC, created DESC"
         elif sortkey == 2:
             orderby_str = "lastmail, created"
+        elif sortkey == -2:
+            orderby_str = "lastmail DESC, created DESC"
         elif sortkey == 3:
             orderby_str = "num_cfs DESC, modified, created"
+        elif sortkey == -3:
+            orderby_str = "num_cfs ASC, modified DESC, created DESC"
         elif sortkey == 4:
             orderby_str = "p.id"
+        elif sortkey == -4:
+            orderby_str = "p.id DESC"
         elif sortkey == 5:
             orderby_str = "p.name, created"
+        elif sortkey == -5:
+            orderby_str = "p.name DESC, created DESC"
         elif sortkey == 6:
             orderby_str = (
                 "branch.all_additions + branch.all_deletions NULLS LAST, created"
+            )
+        elif sortkey == -6:
+            orderby_str = (
+                "branch.all_additions + branch.all_deletions DESC NULLS LAST, created"
             )
         else:
             orderby_str = "p.id"


### PR DESCRIPTION
Implements reverse sorting in the columns of the commitfest pages.

This is a cleaned up version of #28 and #32

Fixes #20 