### PR TITLE
Remove pycrypto and pycryptodome from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 django>=4.2,<5.0
 psycopg2
 simplejson
-pycrypto
 requests
-pycryptodome
 pycryptodomex


### PR DESCRIPTION
These libraries were unused. We only used the APIs from `pycryptodomex`.

Fixes #43
