### PR TITLE
Fix review form checkbox styling

### DIFF
--- a/media/commitfest/css/commitfest.css
+++ b/media/commitfest/css/commitfest.css
@@ -30,6 +30,12 @@ div.form-group div.controls ul li label input {
 }
 div.form-group div.controls input[type="checkbox"] {
     width: 10px;
+    height: unset;
+    display: inline-block;
+}
+div.form-group div.controls > div.form-control:has(input[type="checkbox"]) {
+    display: flex;
+    gap: 8px;
 }
 
 div.form-group div.controls input.threadpick-input {


### PR DESCRIPTION
This fixes an issue I reported on the pgsql-www mailing list [1].

The checkboxes that were present on the review form were not displayed correctly. This makes some small css tweaks to address that problem. A better fix would probably be to generate different HTML, but that would require changing the way forms are rendered by Django for these checkboxes. Which is not trivial to do. So for now this fix is fine.

Before:
![image](https://github.com/user-attachments/assets/af15ec16-116b-43cf-988f-611d3f0b2ffa)

After:
![image](https://github.com/user-attachments/assets/68e720f3-49a7-4b73-b718-b1c56f212d65)

[1]: https://www.postgresql.org/message-id/flat/CADXhmgQbed%2BJP3o5szv15sKsT5gkfZi4urOSLsYoC-oAGepK7g%40mail.gmail.com
