### PR TITLE
Show a CI timeout as a failure

### DIFF
--- a/pgcommitfest/commitfest/templates/commitfest.html
+++ b/pgcommitfest/commitfest/templates/commitfest.html
@@ -101,7 +101,7 @@
     <a href="https://github.com/postgresql-cfbot/postgresql/compare/cf/{{p.id}}~1...cf/{{p.id}}" title="View last patch set on GitHub"><img class="github-logo" src="/media/commitfest/github-mark.svg"/></a>
     <a href="https://cirrus-ci.com/github/postgresql-cfbot/postgresql/cf%2F{{p.id}}"
        title="View CI history{%if p.cfbot_results.failed_task_names %}. Failed jobs: {{p.cfbot_results.failed_task_names}}{%endif%}">
-      {%if p.cfbot_results.failed > 0 %}
+      {%if p.cfbot_results.failed > 0 or p.cfbot_results.branch_status == 'failed' or p.cfbot_results.branch_status == 'timeout' %}
       <img src="/media/commitfest/new_failure.svg"/>
       {%elif p.cfbot_results.completed < p.cfbot_results.total  %}
       <img src="/media/commitfest/running.svg"/>

--- a/pgcommitfest/commitfest/views.py
+++ b/pgcommitfest/commitfest/views.py
@@ -304,6 +304,7 @@ def commitfest(request, cfid):
             count(*) total,
             string_agg(task.task_name, ', ') FILTER (WHERE task.status in ('ABORTED', 'ERRORED', 'FAILED')) as failed_task_names,
             branch.commit_id IS NULL as needs_rebase,
+            branch.status as branch_status,
             branch.apply_url,
             branch.patch_count,
             branch.first_additions,


### PR DESCRIPTION
If things take too long, then CFBot will mark the build as timed out.
Such builds would not have that "timeout" status reflected correctly,
and would be displayed as running forever.

Fixes #39
