### PR TITLE
Remove latest activity column

### DIFF
--- a/pgcommitfest/commitfest/templates/commitfest.html
+++ b/pgcommitfest/commitfest/templates/commitfest.html
@@ -70,7 +70,6 @@
       <th>Reviewers</th>
       <th>Committer</th>
       <th><a href="#" style="color:#333333;" onclick="return sortpatches(3);">Num cfs</a>{%if sortkey == 3%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -3%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
-      <th><a href="#" style="color:#333333;" onclick="return sortpatches(1);">Latest activity</a>{%if sortkey == 1%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -1%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
       <th><a href="#" style="color:#333333;" onclick="return sortpatches(2);">Latest mail</a>{%if sortkey == 2%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -2%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
       {%if user.is_staff%}
        <th>Select</th>
@@ -125,7 +124,6 @@
     <td>{{p.reviewer_names|default:''}}</td>
     <td>{{p.committer|default:''}}</td>
     <td>{{p.num_cfs}}</td>
-    <td style="white-space: nowrap;">{{p.modified|date:"Y-m-d"}}<br/>{{p.modified|date:"H:i"}}</td>
     <td style="white-space: nowrap;">{{p.lastmail|date:"Y-m-d"}}<br/>{{p.lastmail|date:"H:i"}}</td>
     {%if user.is_staff%}
      <td style="white-space: nowrap;"><input type="checkbox" class="sender_checkbox" id="send_authors_{{p.id}}">Author<br/><input type="checkbox" class="sender_checkbox" id="send_reviewers_{{p.id}}">Reviewer</td>

--- a/pgcommitfest/commitfest/views.py
+++ b/pgcommitfest/commitfest/views.py
@@ -239,11 +239,7 @@ def commitfest(request, cfid):
         except ValueError:
             sortkey = 0
 
-        if sortkey == 1:
-            orderby_str = "modified, created"
-        elif sortkey == -1:
-            orderby_str = "modified DESC, created DESC"
-        elif sortkey == 2:
+        if sortkey == 2:
             orderby_str = "lastmail, created"
         elif sortkey == -2:
             orderby_str = "lastmail DESC, created DESC"


### PR DESCRIPTION
Having both "Latest email" and "Latest activity" as a column on the commitfest page is kind of useless. The "Latest activity" often is simply the date that a patch was moved to the next commitfest, so it's content is rather useless in general. If we improve the commitfest app to contain more useful info, then it might become more useful to have this timestamp. For now it seems fine to remove it though. We can always add it back later if it turns out that people miss it.

Fixes #21 