### PR TITLE
Show "Latest email" column as a relative time

### DIFF
--- a/pgcommitfest/commitfest/templates/commitfest.html
+++ b/pgcommitfest/commitfest/templates/commitfest.html
@@ -124,7 +124,7 @@
     <td>{{p.reviewer_names|default:''}}</td>
     <td>{{p.committer|default:''}}</td>
     <td>{{p.num_cfs}}</td>
-    <td style="white-space: nowrap;">{{p.lastmail|date:"Y-m-d"}}<br/>{{p.lastmail|date:"H:i"}}</td>
+    <td style="white-space: nowrap;" title="{{p.lastmail}}">{%if p.lastmail %}{{p.lastmail|timesince}} ago{%endif%}</td>
     {%if user.is_staff%}
      <td style="white-space: nowrap;"><input type="checkbox" class="sender_checkbox" id="send_authors_{{p.id}}">Author<br/><input type="checkbox" class="sender_checkbox" id="send_reviewers_{{p.id}}">Reviewer</td>
     {%endif%}


### PR DESCRIPTION
Exact dates of the last email are usually not super useful when looking at the commitfest page. This instead starts showing a relative time since. For the rare cases where the exact date & time is needed, the tooltip will show the exact date & time. When this gets deployed to prod a small change also needs to be made to the cfbot, because this breaks the cfbot its html scraping.