### PR TITLE
Revamp the homepage to show you patches you might be interested in

### DIFF
--- a/media/commitfest/css/commitfest.css
+++ b/media/commitfest/css/commitfest.css
@@ -87,3 +87,7 @@ div.form-group div.controls input.threadpick-input {
     font-weight: bold;
     color: red;
 }
+
+.search-bar {
+    display: inline-block;
+}

--- a/pgcommitfest/commitfest/forms.py
+++ b/pgcommitfest/commitfest/forms.py
@@ -26,7 +26,10 @@ class CommitFestFilterForm(forms.Form):
         c = [(-1, "* All")] + list(PatchOnCommitFest._STATUS_CHOICES)
         self.fields["status"] = forms.ChoiceField(choices=c, required=False)
 
-        q = Q(patch_author__commitfests=cf) | Q(patch_reviewer__commitfests=cf)
+        if cf:
+            q = Q(patch_author__commitfests=cf) | Q(patch_reviewer__commitfests=cf)
+        else:
+            q = Q()
         userchoices = [(-1, "* All"), (-2, "* None"), (-3, "* Yourself")] + [
             (u.id, "%s %s (%s)" % (u.first_name, u.last_name, u.username))
             for u in User.objects.filter(q)

--- a/pgcommitfest/commitfest/models.py
+++ b/pgcommitfest/commitfest/models.py
@@ -44,6 +44,12 @@ class CommitFest(models.Model):
         (STATUS_INPROGRESS, "In Progress"),
         (STATUS_CLOSED, "Closed"),
     )
+    _STATUS_LABELS = (
+        (STATUS_FUTURE, "default"),
+        (STATUS_OPEN, "info"),
+        (STATUS_INPROGRESS, "success"),
+        (STATUS_CLOSED, "danger"),
+    )
     name = models.CharField(max_length=100, blank=False, null=False, unique=True)
     status = models.IntegerField(
         null=False, blank=False, default=1, choices=_STATUS_CHOICES

--- a/pgcommitfest/commitfest/templates/archive.html
+++ b/pgcommitfest/commitfest/templates/archive.html
@@ -1,0 +1,9 @@
+{%extends "base.html"%}
+{%block contents%}
+ <ul>
+  {%for c in commitfests%}
+   <li><a href="/{{c.id}}/">{{c}}</a> ({{c.statusstring}}{%if c.startdate%} - {{c.periodstring}}{%endif%})</li>
+  {%endfor%}
+ </ul>
+{%endblock%}
+

--- a/pgcommitfest/commitfest/templates/base.html
+++ b/pgcommitfest/commitfest/templates/base.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <title>{{title}}</title>
+  <title>{{title|default:'Commitfest' }}</title>
   <link rel="stylesheet" href="/media/commitfest/css/jquery-ui.css" type="text/css">
   <link rel="stylesheet" href="/media/commitfest/css/bootstrap.css" />
   <link rel="stylesheet" href="/media/commitfest/css/bootstrap-theme.min.css" />
@@ -29,7 +29,9 @@
     {%if header_activity%} <li class="pull-right active"><a href="{{header_activity_link}}">{{header_activity}}</a></li>{%endif%}
    </ul>
 
-   <h1>{{title}}</h1>
+   {%if title %}
+    <h1>{{title}}</h1>
+   {%endif%}
 
    {%if messages%}
     {%for m in messages%}

--- a/pgcommitfest/commitfest/templates/home.html
+++ b/pgcommitfest/commitfest/templates/home.html
@@ -48,13 +48,15 @@
     </tbody>
     </table>
    {%endif%}
-   <h3>{{p.is_open|yesno:"Active patches,Closed patches"}}</h3>
+   <h3>{{user.is_authenticated|yesno:"Your personal dashboard,Patches in the current commitfest"}}</h3>
    <table class="table table-striped table-bordered table-hover table-condensed">
     <thead>
      <tr>
       <th><a href="#" style="color:#333333;" onclick="return sortpatches(5);">Patch</a>{%if sortkey == 5%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -5%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
       <th><a href="#" style="color:#333333;" onclick="return sortpatches(4);">ID</a>{%if sortkey == 4%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -4%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
-      <th><a href="#" style="color:#333333;" onclick="return sortpatches(8);">CF</a>{%if sortkey == 8%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -8%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      {%if user.is_authenticated %}
+       <th><a href="#" style="color:#333333;" onclick="return sortpatches(8);">CF</a>{%if sortkey == 8%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -8%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      {%endif%}
       <th>Status</th>
       <th>Ver</th>
       <th><a href="#" style="color:#333333;" onclick="return sortpatches(7);">CI status</a>{%if sortkey == 7%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -7%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
@@ -74,13 +76,15 @@
 
   {%if grouping%}
    {%ifchanged p.topic%}
-    <tr><th colspan="{%if user.is_staff%}11{%else%}10{%endif%}">{{p.topic}}</th></tr>
+    <tr><th colspan="{%if user.is_staff%}13{%elif user.is_authenticated %}12{%else%}11{%endif%}">{{p.topic}}</th></tr>
    {%endifchanged%}
   {%endif%}
   <tr>
    <td><a href="/patch/{{p.id}}/">{{p.name}}</a></td>
    <td>{{p.id}}</td>
-   <td><a href="/{{p.cf_id}}/"><span class="label label-{{p.cf_status|commitfeststatuslabel}}">{{p.cf_name}}</span></a></td>
+   {%if user.is_authenticated %}
+    <td><a href="/{{p.cf_id}}/"><span class="label label-{{p.cf_status|commitfeststatuslabel}}">{{p.cf_name}}</span></a></td>
+   {%endif%}
    <td><span class="label label-{{p.status|patchstatuslabel}}">{{p.status|patchstatusstring}}</span></td>
    <td>{%if p.targetversion%}<span class="label label-default">{{p.targetversion}}</span>{%endif%}</td>
    <td class="cfbot-summary">

--- a/pgcommitfest/commitfest/templates/home.html
+++ b/pgcommitfest/commitfest/templates/home.html
@@ -1,31 +1,131 @@
 {%extends "base.html"%}
+{%load commitfest %}
 {%block contents%}
- <p>
-  {%if inprogresscf%}A commitfest is currently in progress: <a href="/{{inprogresscf.id}}/">{{inprogresscf}}</a>.{%endif%}
- </p>
- <p>
-  Useful links that you can use and bookmark:
- </p>
- <ul>
-  <li><a href="/current/">All patches in the current commitfest</a></li>
-  <li><a href="/open/">All patches in the open commitfest</a></li>
-  <li><a href="/open/new/">Create a new commitfest entry</a></li>
-  <li><a href="/current/?author=-3">Your entries in the current commitfest</a></li>
-  <li><a href="/open/?author=-3">Your entries in the open commitfest</a></li>
-  <li><a href="/current/?reviewer=-3">Entries that you are reviewing in current commitfest</a></li>
- </ul>
- <h3>Commands</h3>
- <form method="GET" action="/search/" class="form-inline">
+ <a class="btn btn-default" href="/open/new/">New patch</a>
+ <a class="btn btn-default" href="/current/">Current commitfest</a></li>
+ <a class="btn btn-default" href="/open/">Open commitfest</a></li>
+ <a class="btn btn-default" href="/archive/">Archive</a></li>
+ <button type="button" class="btn btn-default{%if has_filter%} active{%endif%}" id="filterButton" onClick="togglePatchFilterButton('filterButton', 'collapseFilters')">Search/filter</button>
+ <form method="GET" action="/search/" class="form-inline search-bar pull-right">
   <div class="form-group">
-   <input type="text" class="form-control" id="searchterm" name="searchterm" placeholder="Global search">
+   <input type="text" class="form-control" id="searchterm" name="searchterm" placeholder="Keyword or Message-ID">
   </div>
   <button type="submit" class="btn btn-default">Search</button>
  </form>
- <h3>List of commitfests</h3>
- <ul>
-  {%for c in commitfests%}
-   <li><a href="/{{c.id}}/">{{c}}</a> ({{c.statusstring}}{%if c.startdate%} - {{c.periodstring}}{%endif%})</li>
-  {%endfor%}
- </ul>
- <br/>
+ <div id="collapseFilters" class="collapse {%if has_filter%}in{%endif%}">
+  <form id="filterform" method="GET" action="." style="margin-bottom: 0px">
+   <table class="table table-condensed" style="margin-bottom: 0px">
+    <thead>
+     <tr>
+      {%for f in form%}
+       {%if not f.is_hidden%}
+        <td>{{f.label}}</td>
+       {%else%}
+        <td></td>
+       {%endif%}
+      {%endfor%}
+	    {%comment%} Add one extra for buttons {%endcomment%}
+      <td></td>
+     </tr>
+    </thead>
+    <tbody>
+     <tr>
+      {%for f in form%}
+       <td>{{f|field_class:"form-control"}}</td>
+      {%endfor%}
+      <td>
+       <input type="submit" class="btn btn-default" value="Filter">
+       <a class="btn btn-default" href=".">Clear</a>
+      </td>
+     </tr>
+    </tbody>
+   </table>
+  </form>
+ </div>
+ {%for p in patches %}
+  {%ifchanged p.is_open%}
+   {%if not forloop.first%}
+    </tbody>
+    </table>
+   {%endif%}
+   <h3>{{p.is_open|yesno:"Active patches,Closed patches"}}</h3>
+   <table class="table table-striped table-bordered table-hover table-condensed">
+    <thead>
+     <tr>
+      <th><a href="#" style="color:#333333;" onclick="return sortpatches(5);">Patch</a>{%if sortkey == 5%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -5%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      <th><a href="#" style="color:#333333;" onclick="return sortpatches(4);">ID</a>{%if sortkey == 4%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -4%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      <th><a href="#" style="color:#333333;" onclick="return sortpatches(8);">CF</a>{%if sortkey == 8%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -8%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      <th>Status</th>
+      <th>Ver</th>
+      <th><a href="#" style="color:#333333;" onclick="return sortpatches(7);">CI status</a>{%if sortkey == 7%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -7%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      <th><a href="#" style="color:#333333;" onclick="return sortpatches(6);">Stats</a>{%if sortkey == 6%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -6%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      <th>Author</th>
+      <th>Reviewers</th>
+      <th>Committer</th>
+      <th><a href="#" style="color:#333333;" onclick="return sortpatches(3);">Num cfs</a>{%if sortkey == 3%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -3%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      <th><a href="#" style="color:#333333;" onclick="return sortpatches(2);">Latest mail</a>{%if sortkey == 2%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-down"></i></div>{%elif sortkey == -2%}<div style="float:right;"><i class="glyphicon glyphicon-arrow-up"></i></div>{%endif%}</th>
+      {%if user.is_staff%}
+       <th>Select</th>
+      {%endif%}
+     </tr>
+    </thead>
+    <tbody>
+  {%endifchanged%}
+
+  {%if grouping%}
+   {%ifchanged p.topic%}
+    <tr><th colspan="{%if user.is_staff%}11{%else%}10{%endif%}">{{p.topic}}</th></tr>
+   {%endifchanged%}
+  {%endif%}
+  <tr>
+   <td><a href="/patch/{{p.id}}/">{{p.name}}</a></td>
+   <td>{{p.id}}</td>
+   <td><a href="/{{p.cf_id}}/"><span class="label label-{{p.cf_status|commitfeststatuslabel}}">{{p.cf_name}}</span></a></td>
+   <td><span class="label label-{{p.status|patchstatuslabel}}">{{p.status|patchstatusstring}}</span></td>
+   <td>{%if p.targetversion%}<span class="label label-default">{{p.targetversion}}</span>{%endif%}</td>
+   <td class="cfbot-summary">
+    {%with p.cfbot_results as cfb%}
+     {%if not cfb %}
+      <span class="label label-default">Not processed</span>
+     {%elif p.needs_rebase_since %}
+      <a href="{{cfb.apply_url}}" title="View git apply logs. Needs rebase since {{p.needs_rebase_since|timesince}}. {%if p.failing_since and p.failing_since != p.needs_rebase_since %}Failing since {{p.failing_since|timesince}}.{%endif%}">
+       <span class="label label-warning">Needs rebase!</span>
+      </a>
+     {%else%}
+      <a href="https://github.com/postgresql-cfbot/postgresql/compare/cf/{{p.id}}~1...cf/{{p.id}}" title="View last patch set on GitHub"><img class="github-logo" src="/media/commitfest/github-mark.svg"/></a>
+      <a href="https://cirrus-ci.com/github/postgresql-cfbot/postgresql/cf%2F{{p.id}}"
+         title="View CI history. {%if p.failing_since%}Failing since {{p.failing_since|timesince}}. {%endif%}{%if cfb.failed_task_names %}Failed jobs: {{cfb.failed_task_names}}{%endif%}">
+       {%if cfb.failed > 0 or cfb.branch_status == 'failed' or cfb.branch_status == 'timeout' %}
+        <img src="/media/commitfest/new_failure.svg"/>
+       {%elif cfb.completed < cfb.total  %}
+        <img src="/media/commitfest/running.svg"/>
+       {%else%}
+        <img src="/media/commitfest/new_success.svg"/>
+       {%endif%}
+       <span class="run-counters">
+        {{cfb.completed}}/{{cfb.total}}
+       </span>
+      </a>
+     {%endif%}
+     </td>
+     <td>
+      {%if cfb and cfb.all_additions is not none %}
+       <span class="additions">+{{ cfb.all_additions }}</span><span class="deletions">&#8722;{{ cfb.all_deletions }}</span>
+      {%endif%}
+     </td>
+    {%endwith%}
+    <td>{{p.author_names|default:''}}</td>
+    <td>{{p.reviewer_names|default:''}}</td>
+    <td>{{p.committer|default:''}}</td>
+    <td>{{p.num_cfs}}</td>
+    <td style="white-space: nowrap;" title="{{p.lastmail}}">{%if p.lastmail %}{{p.lastmail|timesince}} ago{%endif%}</td>
+    {%if user.is_staff%}
+     <td style="white-space: nowrap;"><input type="checkbox" class="sender_checkbox" id="send_authors_{{p.id}}">Author<br/><input type="checkbox" class="sender_checkbox" id="send_reviewers_{{p.id}}">Reviewer</td>
+    {%endif%}
+   </tr>
+   {%if forloop.last%}
+    </tbody>
+    </table>
+   {%endif%}
+ {%endfor%}
 {%endblock%}

--- a/pgcommitfest/commitfest/templatetags/commitfest.py
+++ b/pgcommitfest/commitfest/templatetags/commitfest.py
@@ -3,9 +3,23 @@ from django.template.defaultfilters import stringfilter
 
 from uuid import uuid4
 
-from pgcommitfest.commitfest.models import PatchOnCommitFest
+from pgcommitfest.commitfest.models import CommitFest, PatchOnCommitFest
 
 register = template.Library()
+
+
+@register.filter(name="commitfeststatusstring")
+@stringfilter
+def commitfeststatusstring(value):
+    i = int(value)
+    return [v for k, v in CommitFest._STATUS_CHOICES if k == i][0]
+
+
+@register.filter(name="commitfeststatuslabel")
+@stringfilter
+def commitfeststatuslabel(value):
+    i = int(value)
+    return [v for k, v in CommitFest._STATUS_LABELS if k == i][0]
 
 
 @register.filter(name="patchstatusstring")

--- a/pgcommitfest/urls.py
+++ b/pgcommitfest/urls.py
@@ -15,6 +15,7 @@ admin.autodiscover()
 
 urlpatterns = [
     re_path(r"^$", views.home),
+    re_path(r"^archive/$", views.archive),
     re_path(r"^activity(?P<rss>\.rss)?/", views.activity),
     re_path(r"^(\d+)/$", views.commitfest),
     re_path(r"^(open|inprogress|current)/(.*)$", views.redir),


### PR DESCRIPTION
The homepage was not showing a lot of useful information. It had a list of mostly ancient commitfests, a search box, and a few links to more useful pages. This revamps the homepage with an initial version of a personalized dashboard. The dashboard shows patches that the user is subscribed to, either because they are marked as an author or a reviewer. We then try to group and sort these patches in an attempt to let the user easily find the patches that require their attention.

Many things can likely be tweaked/improved. I think this first version is already a huge improvement over the status quo, so I think it's worth committing deploying this mostly as is and then iterating on it based on feedback.

This is what it looks like:
![screenshot of homepage](https://github.com/user-attachments/assets/6f464597-30f9-4f4b-9b98-17ac90b64b60)

Fixes #36 