### PR TITLE
Added GitHub contribution link in the header

### DIFF
--- a/pgcommitfest/commitfest/templates/base.html
+++ b/pgcommitfest/commitfest/templates/base.html
@@ -2,65 +2,65 @@
 <!DOCTYPE html>
 <html>
 
-  <head>
-    <title>{{title|default:'Commitfest' }}</title>
-    <link rel="stylesheet" href="/media/commitfest/css/jquery-ui.css" type="text/css">
-    <link rel="stylesheet" href="/media/commitfest/css/bootstrap.css" />
-    <link rel="stylesheet" href="/media/commitfest/css/bootstrap-theme.min.css" />
-    <link rel="stylesheet" href="/media/commitfest/css/commitfest.css?{% static_file_param %}" />
-    <link rel="shortcut icon" href="/media/commitfest/favicon.ico" />
-    {%block extrahead%}{%endblock%}
-    {%if rss_alternate%}
-      <link rel="alternate" type="application/rss+xml" title="{{rss_alternate_title}}" href="{{rss_alternate}}" />{%endif%}
-  </head>
+ <head>
+  <title>{{title|default:'Commitfest' }}</title>
+  <link rel="stylesheet" href="/media/commitfest/css/jquery-ui.css" type="text/css">
+  <link rel="stylesheet" href="/media/commitfest/css/bootstrap.css" />
+  <link rel="stylesheet" href="/media/commitfest/css/bootstrap-theme.min.css" />
+  <link rel="stylesheet" href="/media/commitfest/css/commitfest.css?{% static_file_param %}" />
+  <link rel="shortcut icon" href="/media/commitfest/favicon.ico" />
+  {%block extrahead%}{%endblock%}
+  {%if rss_alternate%}
+   <link rel="alternate" type="application/rss+xml" title="{{rss_alternate_title}}" href="{{rss_alternate}}" />{%endif%}
+ </head>
 
-  <body>
-    <div class="container-fluid">
-      <ul class="breadcrumb">
-        {%if title %}
-          <li><a href="/">Home</a></li>
-          {%for c in breadcrumbs%}
-            <li><a href="{{c.href}}">{{c.title}}</a></li>
-          {%endfor%}
-          <li class="active">{{title}}</li>
-        {%else%}
-          <li class="active">Home</li>
-        {%endif%}
-        <li class="pull-right active">
-          {%if user.is_authenticated%}
-            Logged in as {{user}} (<a href="/account/profile/">edit profile</a> | <a href="/account/logout/">log out</a>{%if
-            user.is_staff%} | <a href="/admin/">administration</a>{%endif%})
-          {%else%}
-            <a href="/account/login/?next={{request.path}}">Log in</a>
-          {%endif%}
-        </li>
-        <li class="pull-right active">
-          <a href="https://github.com/postgres/pgcommitfest" target="_blank"
-             style="color: white; padding: 8px 12px; background-color: #24292e; border-radius: 5px; text-decoration: none;">
-            Contribute on GitHub
-          </a>
-        </li>
-        {%if header_activity%} <li class="pull-right active"><a href="{{header_activity_link}}">{{header_activity}}</a>
-        </li>{%endif%}
-      </ul>
+ <body>
+  <div class="container-fluid">
+   <ul class="breadcrumb">
+    {%if title %}
+     <li><a href="/">Home</a></li>
+     {%for c in breadcrumbs%}
+      <li><a href="{{c.href}}">{{c.title}}</a></li>
+     {%endfor%}
+     <li class="active">{{title}}</li>
+    {%else%}
+     <li class="active">Home</li>
+    {%endif%}
+    <li class="pull-right active">
+     {%if user.is_authenticated%}
+      Logged in as {{user}} (<a href="/account/profile/">edit profile</a> | <a href="/account/logout/">log out</a>{%if
+      user.is_staff%} | <a href="/admin/">administration</a>{%endif%})
+     {%else%}
+      <a href="/account/login/?next={{request.path}}">Log in</a>
+     {%endif%}
+    </li>
+    <li class="pull-right active">
+     <a href="https://github.com/postgres/pgcommitfest" target="_blank"
+        style="color: white; padding: 8px 12px; background-color: #24292e; border-radius: 5px; text-decoration: none;">
+      Contribute on GitHub
+     </a>
+    </li>
+    {%if header_activity%} <li class="pull-right active"><a href="{{header_activity_link}}">{{header_activity}}</a>
+    </li>{%endif%}
+   </ul>
 
-      {%if title %}
-        <h1>{{title}}</h1>
-      {%endif%}
+   {%if title %}
+    <h1>{{title}}</h1>
+   {%endif%}
 
-      {%if messages%}
-        {%for m in messages%}
-          <div class="alert {{m.tags|alertmap}}">{{m}}</div>
-        {%endfor%}
-      {%endif%}
+   {%if messages%}
+    {%for m in messages%}
+     <div class="alert {{m.tags|alertmap}}">{{m}}</div>
+    {%endfor%}
+   {%endif%}
 
-      {%block contents%}
-      {%endblock%}
-    </div>
-    <script src="/media/commitfest/js/jquery.js"></script>
-    <script src="/media/commitfest/js/jquery-ui.js"></script>
-    <script src="/media/commitfest/js/bootstrap.js"></script>
-    <script src="/media/commitfest/js/commitfest.js?{% static_file_param %}"></script>
-    {%block morescript%}{%endblock%}
+   {%block contents%}
+   {%endblock%}
+  </div>
+  <script src="/media/commitfest/js/jquery.js"></script>
+  <script src="/media/commitfest/js/jquery-ui.js"></script>
+  <script src="/media/commitfest/js/bootstrap.js"></script>
+  <script src="/media/commitfest/js/commitfest.js?{% static_file_param %}"></script>
+  {%block morescript%}{%endblock%}
 
-  </html>
+ </html>

--- a/pgcommitfest/commitfest/templates/base.html
+++ b/pgcommitfest/commitfest/templates/base.html
@@ -1,59 +1,66 @@
 {%load commitfest%}
 <!DOCTYPE html>
 <html>
- <head>
-  <title>{{title|default:'Commitfest' }}</title>
-  <link rel="stylesheet" href="/media/commitfest/css/jquery-ui.css" type="text/css">
-  <link rel="stylesheet" href="/media/commitfest/css/bootstrap.css" />
-  <link rel="stylesheet" href="/media/commitfest/css/bootstrap-theme.min.css" />
-  <link rel="stylesheet" href="/media/commitfest/css/commitfest.css?{% static_file_param %}" />
-  <link rel="shortcut icon" href="/media/commitfest/favicon.ico" />
-  {%block extrahead%}{%endblock%}
-  {%if rss_alternate%}  <link rel="alternate" type="application/rss+xml" title="{{rss_alternate_title}}" href="{{rss_alternate}}" />{%endif%}
- </head>
- <body>
-  <div class="container-fluid">
-   <ul class="breadcrumb">
-    {%if title %}
-     <li><a href="/">Home</a></li>
-     {%for c in breadcrumbs%}
-      <li><a href="{{c.href}}">{{c.title}}</a></li>
-     {%endfor%}
-     <li class="active">{{title}}</li>
-    {%else%}
-     <li class="active">Home</li>
-    {%endif%}
-    <li class="pull-right active">
-     {%if user.is_authenticated%}
-      Logged in as {{user}} (<a href="/account/profile/">edit profile</a> | <a href="/account/logout/">log out</a>{%if user.is_staff%} | <a href="/admin/">administration</a>{%endif%})
-     {%else%}
-      <a href="/account/login/?next={{request.path}}">Log in</a>
-     {%endif%}
-    </li>
-    <li class="pull-right active">
-        <a href="https://github.com/postgres/pgcommitfest" target="_blank" style="color: white; padding: 8px 12px; background-color: #24292e; border-radius: 5px; text-decoration: none;">
-          Contribute on GitHub
-        </a>
-      </li>
-    {%if header_activity%} <li class="pull-right active"><a href="{{header_activity_link}}">{{header_activity}}</a></li>{%endif%}
-   </ul>
 
-   {%if title %}
-    <h1>{{title}}</h1>
-   {%endif%}
+  <head>
+    <title>{{title|default:'Commitfest' }}</title>
+    <link rel="stylesheet" href="/media/commitfest/css/jquery-ui.css" type="text/css">
+    <link rel="stylesheet" href="/media/commitfest/css/bootstrap.css" />
+    <link rel="stylesheet" href="/media/commitfest/css/bootstrap-theme.min.css" />
+    <link rel="stylesheet" href="/media/commitfest/css/commitfest.css?{% static_file_param %}" />
+    <link rel="shortcut icon" href="/media/commitfest/favicon.ico" />
+    {%block extrahead%}{%endblock%}
+    {%if rss_alternate%}
+      <link rel="alternate" type="application/rss+xml" title="{{rss_alternate_title}}" href="{{rss_alternate}}" />{%endif%}
+  </head>
 
-   {%if messages%}
-    {%for m in messages%}
-     <div class="alert {{m.tags|alertmap}}">{{m}}</div>
-    {%endfor%}
-   {%endif%}
+  <body>
+    <div class="container-fluid">
+      <ul class="breadcrumb">
+        {%if title %}
+          <li><a href="/">Home</a></li>
+          {%for c in breadcrumbs%}
+            <li><a href="{{c.href}}">{{c.title}}</a></li>
+          {%endfor%}
+          <li class="active">{{title}}</li>
+        {%else%}
+          <li class="active">Home</li>
+        {%endif%}
+        <li class="pull-right active">
+          {%if user.is_authenticated%}
+            Logged in as {{user}} (<a href="/account/profile/">edit profile</a> | <a href="/account/logout/">log out</a>{%if
+            user.is_staff%} | <a href="/admin/">administration</a>{%endif%})
+          {%else%}
+            <a href="/account/login/?next={{request.path}}">Log in</a>
+          {%endif%}
+        </li>
+        <li class="pull-right active">
+          <a href="https://github.com/postgres/pgcommitfest" target="_blank"
+             style="color: white; padding: 8px 12px; background-color: #24292e; border-radius: 5px; text-decoration: none;">
+            Contribute on GitHub
+          </a>
+        </li>
+        {%if header_activity%} <li class="pull-right active"><a href="{{header_activity_link}}">{{header_activity}}</a>
+        </li>{%endif%}
+      </ul>
 
-   {%block contents%}
-   {%endblock%}
-  </div>
-  <script src="/media/commitfest/js/jquery.js"></script>
-  <script src="/media/commitfest/js/jquery-ui.js"></script>
-  <script src="/media/commitfest/js/bootstrap.js"></script>
-  <script src="/media/commitfest/js/commitfest.js?{% static_file_param %}"></script>
-  {%block morescript%}{%endblock%}
- </html>
+      {%if title %}
+        <h1>{{title}}</h1>
+      {%endif%}
+
+      {%if messages%}
+        {%for m in messages%}
+          <div class="alert {{m.tags|alertmap}}">{{m}}</div>
+        {%endfor%}
+      {%endif%}
+
+      {%block contents%}
+      {%endblock%}
+    </div>
+    <script src="/media/commitfest/js/jquery.js"></script>
+    <script src="/media/commitfest/js/jquery-ui.js"></script>
+    <script src="/media/commitfest/js/bootstrap.js"></script>
+    <script src="/media/commitfest/js/commitfest.js?{% static_file_param %}"></script>
+    {%block morescript%}{%endblock%}
+
+  </html>

--- a/pgcommitfest/commitfest/templates/base.html
+++ b/pgcommitfest/commitfest/templates/base.html
@@ -30,6 +30,11 @@
       <a href="/account/login/?next={{request.path}}">Log in</a>
      {%endif%}
     </li>
+    <li class="pull-right active">
+        <a href="https://github.com/postgres/pgcommitfest" target="_blank" style="color: white; padding: 8px 12px; background-color: #24292e; border-radius: 5px; text-decoration: none;">
+          Contribute on GitHub
+        </a>
+      </li>
     {%if header_activity%} <li class="pull-right active"><a href="{{header_activity_link}}">{{header_activity}}</a></li>{%endif%}
    </ul>
 


### PR DESCRIPTION
closes #38 
This PR adds a "Contribute on GitHub" link in the header, making it easier for users to find the repository and contribute. 
- The link directs users to the pgcommitfest GitHub repo.
- Styled with a GitHub-like dark button for better visibility.

Fixes: #38 
