### PR TITLE
Provide a title to the profile edit screen

### DIFF
--- a/pgcommitfest/userprofile/views.py
+++ b/pgcommitfest/userprofile/views.py
@@ -27,5 +27,6 @@ def userprofile(request):
         "userprofileform.html",
         {
             "form": form,
+            "title": "Profile",
         },
     )


### PR DESCRIPTION
This solves the issue #56, as that seems to be caused by a lack of "title" field in template parameters in:
https://github.com/postgres/pgcommitfest/blob/main/pgcommitfest/commitfest/templates/base.html#L17-L25

Fixes #56 