### PR TITLE
Add .inc files to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.html]
+[*.{html,inc}]
 indent_style = space
 indent_size = 1


### PR DESCRIPTION
HTML template subcomponent filenames get prefixed with .inc but are just html-like files and thus have the same layout enforced as .html files.