### PR TITLE
Fix links not appearing in patch page

### DIFF
--- a/pgcommitfest/commitfest/templates/patch.html
+++ b/pgcommitfest/commitfest/templates/patch.html
@@ -106,11 +106,15 @@
    </tr>
    <tr>
     <th>Links</th>
-    {%if patch.wikilink%}
-     <a href="{{patch.wikilink}}">Wiki</a>{%endif%}{%if patch.gitlink%}
-      <a href="{{patch.gitlink}}">Git</a>
-     {%endif%}</td>
-  </tr>
+    <td>
+     {% if patch.wikilink %}
+      <a href="{{ patch.wikilink }}">Wiki</a>
+     {% endif %}
+     {% if patch.gitlink %}
+      <a href="{{ patch.gitlink }}">Git</a>
+     {% endif %}
+    </td>
+   </tr>
   <tr>
    <th>Emails</th>
    <td>


### PR DESCRIPTION
I noticed links are not visible in the patch page

<img width="435" alt="image" src="https://github.com/user-attachments/assets/2d794272-9734-4c99-acd5-d381d8da278c" />
