### PR TITLE
Hide closed patches section for draft commitfests

### DIFF
--- a/pgcommitfest/commitfest/templates/commitfest.html
+++ b/pgcommitfest/commitfest/templates/commitfest.html
@@ -22,13 +22,16 @@
   <b>Status summary: </b>{%for id,title,num in statussummary%}<a href="?status={{id}}">{{title}}</a>: {{num}}. {%endfor%}
  </p>
 
- {%for p in patches %}
+{%for p in patches %}
   {%ifchanged p.is_open%}
+   {% if not cf.draft or p.is_open %}
    {%if not forloop.first%}
     </tbody>
     </table>
    {%endif%}
-   <h3>{{p.is_open|yesno:"Active patches,Closed patches"}}</h3>
+{% if not cf.draft or p.is_open %}
+  <h3>{{p.is_open|yesno:"Active patches,Closed patches"}}</h3>
+{% endif %}
    <table class="table table-striped table-bordered table-hover">
     <thead>
      <tr>


### PR DESCRIPTION
Fixes #91

Currently, draft commitfests still render the "Closed patches" section in the template, even though backend logic already excludes the "Moved to other CF" status.

This change updates the template to hide the entire "Closed patches" section when the commitfest is marked as draft.

As a result:
- Draft commitfests only display active patches.
- Non-draft commitfests continue to display both active and closed patches.

Tested locally with:

- Draft commitfest → only active patches visible
- Regular commitfest → both active and closed sections visible